### PR TITLE
derive bundling architecture from lambda

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -48,6 +48,7 @@ export class RustFunction extends lambda.Function {
     super(scope, packageName, {
       ...props,
       runtime,
+      architecture: bundling.architecture,
       code: Bundling.bundle({
         ...bundling,
         packageName,

--- a/src/function.ts
+++ b/src/function.ts
@@ -34,6 +34,15 @@ export interface RustFunctionProps extends lambda.FunctionOptions {
   readonly bundling?: BundlingOptions;
 }
 
+function bundlingOptionsFromRustFunctionProps(
+  props?: RustFunctionProps,
+): BundlingOptions {
+  const bundling = props?.bundling ?? {};
+  return {
+    ...bundling,
+  };
+}
+
 /**
  * A Rust Lambda function
  */
@@ -42,7 +51,7 @@ export class RustFunction extends lambda.Function {
     const manifestPath = getCargoManifestPath(props?.manifestPath ?? 'Cargo.toml');
 
     const runtime = lambda.Runtime.PROVIDED_AL2;
-    const bundling = props?.bundling ?? {};
+    const bundling = bundlingOptionsFromRustFunctionProps(props);
 
     super(scope, packageName, {
       ...props,

--- a/src/function.ts
+++ b/src/function.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import { Bundling } from './bundling';
 import { getCargoManifestPath } from './cargo';
 import { BundlingOptions } from './types';
+import { bundlingOptionsFromRustFunctionProps } from './util';
 
 export { cargoLambdaVersion } from './bundling';
 
@@ -34,15 +35,6 @@ export interface RustFunctionProps extends lambda.FunctionOptions {
   readonly bundling?: BundlingOptions;
 }
 
-function bundlingOptionsFromRustFunctionProps(
-  props?: RustFunctionProps,
-): BundlingOptions {
-  const bundling = props?.bundling ?? {};
-  return {
-    ...bundling,
-  };
-}
-
 /**
  * A Rust Lambda function
  */
@@ -66,4 +58,3 @@ export class RustFunction extends lambda.Function {
     });
   }
 }
-

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,7 @@
 import { spawnSync, SpawnSyncOptions } from 'child_process';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { RustFunctionProps } from './function';
+import { BundlingOptions } from './types';
 
 /**
  * Spawn sync with error handling
@@ -18,4 +21,16 @@ export function exec(cmd: string, args: string[], options?: SpawnSyncOptions) {
   }
 
   return proc;
+}
+
+export function bundlingOptionsFromRustFunctionProps(props?: RustFunctionProps): BundlingOptions {
+  const architecture = props?.bundling?.architecture
+    ? props?.bundling?.architecture
+    : props?.architecture
+      ? props?.architecture
+      : lambda.Architecture.X86_64;
+  return {
+    ...props?.bundling,
+    architecture,
+  };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,6 +24,11 @@ export function exec(cmd: string, args: string[], options?: SpawnSyncOptions) {
 }
 
 export function bundlingOptionsFromRustFunctionProps(props?: RustFunctionProps): BundlingOptions {
+  if (props?.bundling?.architecture && props?.architecture && props?.bundling?.architecture !== props?.architecture) {
+    throw new Error(
+      `Architecture mismatch: the architecture for bundling (${props.bundling.architecture.name} ) didn't match the architecture of the underlying lambda (${props.architecture.name}).`,
+    );
+  }
   const architecture = props?.bundling?.architecture
     ? props?.bundling?.architecture
     : props?.architecture

--- a/test/bundlingOptions.test.ts
+++ b/test/bundlingOptions.test.ts
@@ -1,0 +1,42 @@
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { bundlingOptionsFromRustFunctionProps } from '../src/util';
+
+describe('bundlingOptionsFromRustFunctionProps', () => {
+  describe('architecture', () => {
+    it('uses `X86_64` when no props are given', () => {
+      expect(bundlingOptionsFromRustFunctionProps().architecture).toEqual(lambda.Architecture.X86_64);
+    });
+
+    it('uses `X86_64` when no props regarding architecture are given', () => {
+      expect(bundlingOptionsFromRustFunctionProps({ bundling: {} }).architecture).toEqual(lambda.Architecture.X86_64);
+    });
+
+    it('uses the `RustFunctionProps.architecture` when set', () => {
+      expect(
+        bundlingOptionsFromRustFunctionProps({
+          architecture: lambda.Architecture.ARM_64,
+        }).architecture,
+      ).toEqual(lambda.Architecture.ARM_64);
+    });
+
+    it('uses the `BundlingOptions.architecture` when set', () => {
+      expect(
+        bundlingOptionsFromRustFunctionProps({
+          bundling: { architecture: lambda.Architecture.ARM_64 },
+        }).architecture,
+      ).toEqual(lambda.Architecture.ARM_64);
+    });
+
+    it('throws an error when there is an architecture mismatch', () => {
+      expect(
+        () =>
+          bundlingOptionsFromRustFunctionProps({
+            architecture: lambda.Architecture.X86_64,
+            bundling: { architecture: lambda.Architecture.ARM_64 },
+          }).architecture,
+      ).toThrow(
+        "Architecture mismatch: the architecture for bundling (arm64 ) didn't match the architecture of the underlying lambda (x86_64).",
+      );
+    });
+  });
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { env } from 'process';
 import * as cdk from 'aws-cdk-lib/core';
-import { RustExtension, RustFunction, cargoLambdaVersion } from '../lib/index';
+import { RustExtension, RustFunction, cargoLambdaVersion } from '../src/index';
 
 const forcedDockerBundling = !!env.FORCE_DOCKER_RUN || !cargoLambdaVersion();
 


### PR DESCRIPTION
Fixes #https://github.com/cargo-lambda/cargo-lambda-cdk/issues/9

As part of this PR:

* the architecture of the underlying lambda gets set explicitly
* the default architecture (if none is given) is set to `x86_64`