### PR TITLE
Explicitly typed supported runtimes

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,7 +28,7 @@ lambda-project
 
 ### Runtime
 
-The `RustFunction` uses the `PROVIDED_AL2` runtime.
+The `RustFunction` uses the `PROVIDED_AL2023` runtime as default. Alternatively `PROVIDED_AL2` can be configured explicitly.
 
 ## Rust Extension
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -18,10 +18,8 @@ export interface RustFunctionProps extends FunctionOptions {
 
   /**
    * The Lambda runtime to deploy this function with. `provided.al2023` is the default.
-   *
-   * The only valid values are `provided.al2023` and `provided.al2`.
    */
-  readonly runtime?: string;
+  readonly runtime?: 'provided.al2023' | 'provided.al2';
 
   /**
    * Path to a directory containing your Cargo.toml file, or to your Cargo.toml directly.


### PR DESCRIPTION
This PR makes the supported lambda runtimes part of the type. This gives code completion and error messages.

<img width="915" alt="Screenshot 2023-11-16 at 20 11 38" src="https://github.com/cargo-lambda/cargo-lambda-cdk/assets/352753/f4529ae3-1692-4c11-a6e9-15a16c24d132">
