### PR TITLE
Fix release workflow by upgrading cargo-lambda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: cargo-lambda/cargo-lambda
-          tag: v1.1.0
+          tag: v1.2.1
           platform: linux
           arch: x86_64
       - uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: cargo-lambda/cargo-lambda
-          tag: v0.14.0
+          tag: v1.2.1
           platform: linux
           arch: x86_64
       - uses: actions/setup-node@v3


### PR DESCRIPTION
The release workflow seems to be [broken](https://github.com/cargo-lambda/cargo-lambda-cdk/actions/runs/8363056734/job/22895120075) after merging PR #41 due to its use of an old version of cargo-lambda. This PR updates it to the latest version in both the build and release workflows.