### PR TITLE
fix(ci): Cleanup dist/js before creating a new JS package.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
       - name: Create JS Artifact
-        run: npx projen package:js
+        run: rm -rf dist/js && npx projen package:js
       - name: Release JS Artifact
         env:
           NPM_DIST_TAG: latest


### PR DESCRIPTION
Because Projen leaves packages with version 0.0.0 behind.