### PR TITLE
fix: `manifestPath` and `gitRemote` logic

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 David Calavera
+Copyright (c) 2025 David Calavera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -64,10 +64,10 @@ export function getManifestPath(project: CargoProject): string {
       if (gitReference !== 'HEAD') {
         exec('git', ['checkout', gitReference], { cwd: localPath });
       }
-
-      // Append Cargo.toml to the path
-      manifestPath = join(localPath, defaultManifestPath);
     }
+
+    // Append Cargo.toml to the path
+    manifestPath = join(localPath, defaultManifestPath);
   }
 
   let manifestPathResult;


### PR DESCRIPTION
Closes #73 

### Changes
* Always update the `manifestPath` when using a git remote, even if the directory has been cached.