### PR TITLE
chore: run projen synthesis to fix release pipeline

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -49,7 +49,7 @@ project.addBundledDeps('js-toml@^1.0.2');
 // js-toml -> chevrotain -> lodash-es@4.17.21 is vulnerable
 // Force chevrotain@11.1.1+ which uses lodash-es@4.17.23 (patched)
 project.package.addField('resolutions', {
-  'chevrotain': '^11.1.1',
+  chevrotain: '^11.1.1',
 });
 
 project.addGitIgnore('target');

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025 David Calavera
+Copyright (c) 2026 David Calavera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Fixes the release pipeline failure introduced after #88 was merged
- Runs `npx projen` to regenerate managed files, resolving the dirty tree check (`git diff --exit-code`) in the release workflow

## Changes

- **`.projenrc.js`**: Quote style normalization (`'chevrotain'` → `chevrotain`) applied by projen's linter
- **`LICENSE`**: Copyright year updated from 2025 to 2026 (projen auto-generates this)

## Context

The [release workflow run](https://github.com/cargo-lambda/cargo-lambda-cdk/actions/runs/21760301132/job/62781853465) failed because projen synthesis produced a different output than what was committed.